### PR TITLE
FIX: wrong mfeclass selected in SPA handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.1
 	github.com/rs/zerolog v1.31.0
+	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/contrib/exporters/autoexport v0.47.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0
 	go.opentelemetry.io/otel v1.22.0
@@ -57,6 +58,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect

--- a/main.go
+++ b/main.go
@@ -214,6 +214,7 @@ func startHTTPServer(
 }
 
 func initTelemetry(ctx context.Context, logger *zerolog.Logger) (shutdown func(context.Context) error, err error) {
+	// prometheus exporter will be in conflict with kubebuilder metrics server
 	metricReader, err := autoexport.NewMetricReader(ctx)
 	if err != nil {
 		return nil, err

--- a/web-server/internal/polyfea/spa.go
+++ b/web-server/internal/polyfea/spa.go
@@ -60,7 +60,7 @@ func (s *SingePageApplication) HandleSinglePageApplication(w http.ResponseWriter
 		))
 	defer span.End()
 
-	basePath, microFrontendClass, err := s.getMicrofrontendAndBase(r.URL.Path)
+	basePath, microFrontendClass, err := s.getMicrofrontendClassAndBase(r.URL.Path)
 
 	if err != nil {
 		logger.Warn().Err(err).Msg("Error while getting microfrontend and base")
@@ -141,7 +141,7 @@ func (s *SingePageApplication) HandleBootJs(w http.ResponseWriter, r *http.Reque
 		))
 	defer span.End()
 
-	_, microFrontendClass, err := s.getMicrofrontendAndBase(r.URL.Path)
+	_, microFrontendClass, err := s.getMicrofrontendClassAndBase(r.URL.Path)
 
 	if err != nil {
 		logger.Warn().Err(err).Msg("Error while getting microfrontend and base")
@@ -197,7 +197,7 @@ func generateNonce() (string, error) {
 	return nonce, nil
 }
 
-func (s *SingePageApplication) getMicrofrontendAndBase(requestPath string) (string, *v1alpha1.MicroFrontendClass, error) {
+func (s *SingePageApplication) getMicrofrontendClassAndBase(requestPath string) (string, *v1alpha1.MicroFrontendClass, error) {
 
 	slash := func(in string) string {
 		if in[len(in)-1] != '/' {
@@ -220,17 +220,19 @@ func (s *SingePageApplication) getMicrofrontendAndBase(requestPath string) (stri
 	}
 
 	if len(microFrontendClasses) == 0 {
-		return "", nil, nil
+		return "/", nil, nil
 	}
 
 	baseHref := "/"
+	longestMfc := microFrontendClasses[0]
 	// find longest match
 	for _, mfc := range microFrontendClasses {
 		mfcBase := slash(*mfc.Spec.BaseUri)
 		if len(mfcBase) > len(baseHref) {
 			baseHref = mfcBase
+			longestMfc = mfc
 		}
 	}
 
-	return baseHref, microFrontendClasses[0], nil
+	return baseHref, longestMfc, nil
 }

--- a/web-server/internal/polyfea/spa_test.go
+++ b/web-server/internal/polyfea/spa_test.go
@@ -34,10 +34,6 @@ var spaTestSuite = IntegrationTestSuite{
 			Name: "PolyfeaSinglePageApplicationReturnsBootJsWhenRequested",
 			Func: PolyfeaSinglePageApplicationReturnsBootJsWhenRequested,
 		},
-		{
-			Name: "PolyfeaSinglePageApplicationReturnsTemplatedHtmlWithCorrectBaseHref",
-			Func: PolyfeaSinglePageApplicationReturnsTemplatedHtmlWithCorrectBaseHref,
-		},
 	},
 }
 
@@ -129,38 +125,6 @@ func PolyfeaSinglePageApplicationReturnsTemplatedHtmlIfAnythingBesidesPolyfeaIsR
 
 	if strings.Contains(bodyString, "}") != false {
 		t.Fatalf("expected body to not contain %s", "}")
-	}
-}
-
-func PolyfeaSinglePageApplicationReturnsTemplatedHtmlWithCorrectBaseHref(t *testing.T) {
-	// Arrange
-	testServerUrl := os.Getenv(TestServerUrlName)
-
-	// Act
-	response, err := http.Get(testServerUrl + "/other/qweqwesop")
-
-	// Assert
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		t.Fatalf("expected status code %d, got %d", http.StatusOK, response.StatusCode)
-	}
-
-	if response.Header.Get("Content-Type") != "text/html; charset=utf-8" {
-		t.Fatalf("expected content type %s, got %s", "text/html; charset=utf-8", response.Header.Get("Content-Type"))
-	}
-
-	bodyBytes, err := io.ReadAll(response.Body)
-	if err != nil {
-		t.Error(err)
-	}
-	bodyString := string(bodyBytes)
-
-	if strings.Contains(bodyString, "<base href=\"/other/\"") == false {
-		t.Fatalf("expected base href not found in rendered document")
 	}
 }
 

--- a/web-server/internal/polyfea/spa_unit_test.go
+++ b/web-server/internal/polyfea/spa_unit_test.go
@@ -1,0 +1,91 @@
+package polyfea
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/polyfea/polyfea-controller/api/v1alpha1"
+	"github.com/polyfea/polyfea-controller/repository"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type SpaTestSuite struct {
+	suite.Suite
+	mfcRepository repository.PolyfeaRepository[*v1alpha1.MicroFrontendClass]
+}
+
+func TestSpaTestSuite(t *testing.T) {
+	suite.Run(t, new(SpaTestSuite))
+}
+
+func (suite *SpaTestSuite) SetupTest() {
+	suite.SetupMfcRepository()
+}
+func (suite *SpaTestSuite) SetupMfcRepository() {
+	suite.mfcRepository = repository.NewInMemoryPolyfeaRepository[*v1alpha1.MicroFrontendClass]()
+	defaultBase := "/"
+	suite.mfcRepository.StoreItem(&v1alpha1.MicroFrontendClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.MicroFrontendClassSpec{
+			BaseUri: &defaultBase,
+		},
+	})
+
+	feaBase := "/fea/"
+	suite.mfcRepository.StoreItem(&v1alpha1.MicroFrontendClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fea",
+			Namespace: "feas",
+		},
+		Spec: v1alpha1.MicroFrontendClassSpec{
+			BaseUri: &feaBase,
+		},
+	})
+
+	featureBase := "/feature/"
+	suite.mfcRepository.StoreItem(&v1alpha1.MicroFrontendClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "feature",
+			Namespace: "features",
+		},
+		Spec: v1alpha1.MicroFrontendClassSpec{
+			BaseUri: &featureBase,
+		},
+	})
+}
+
+func (suite *SpaTestSuite) TestGetMicrofrontendAndBase() {
+	testParams := []struct {
+		requestPath     string
+		expectBasePath  string
+		expectClassName string
+	}{
+		{"/nonexistent", "/", "default"},
+		{"/fea/asset", "/fea/", "fea"},
+		{"/fea", "/fea/", "fea"},
+		{"/feature", "/feature/", "feature"},
+		{"/feature/asset", "/feature/", "feature"},
+		{"/fea-nix", "/", "default"},
+		{"/other/qweqwesop", "/", "default"},
+	}
+
+	for _, params := range testParams {
+		suite.Run(params.requestPath, func() {
+			// Arrange
+			sut := NewSinglePageApplication(suite.mfcRepository, &zerolog.Logger{})
+			// Act
+			basePath, microfrontend, err := sut.getMicrofrontendClassAndBase(params.requestPath)
+
+			// Assert
+			suite.Nil(err)
+			suite.Equal(params.expectBasePath, basePath)
+			suite.Equal(params.expectClassName, microfrontend.Name)
+		})
+	}
+
+}


### PR DESCRIPTION
bug in implementation of the getMicrofrontendClassAndBase returned always the first mfc even if longest match was on other 